### PR TITLE
Do not set TreatControlCAsInput when using a qglFile as input. 

### DIFF
--- a/FxGql/FxGqlC/Main.cs
+++ b/FxGql/FxGqlC/Main.cs
@@ -224,7 +224,10 @@ namespace FxGqlC
 				return;
 			}
 			
-			Console.TreatControlCAsInput = false;
+			if (string.IsNullOrEmpty(gqlFile)) {
+				Console.TreatControlCAsInput = false;
+			}
+			
 			Console.CancelKeyPress += delegate(object sender, ConsoleCancelEventArgs e) {
 				if (e.SpecialKey == ConsoleSpecialKey.ControlC) {
 					//Console.WriteLine ("===== Ctrl-C signal received =====");


### PR DESCRIPTION
This allows FxGqlC to integrate with Programmers Notepad.
Now using FxGqlc used as an external tool in PN using the following command:   fxgqlc -gqlfile "%d%d" 
causes an invalid input exception. This is caused by setting the TreatControlCAsInput input to false in an non-console environment.

Special thanks to Dieter Tack.

Best regards
Wimmer
